### PR TITLE
[Andrey/Tom] Don't add an input stream if it's null.

### DIFF
--- a/src/main/java/com/zam/logviewer/renderers/FIXRenderer.java
+++ b/src/main/java/com/zam/logviewer/renderers/FIXRenderer.java
@@ -84,12 +84,22 @@ public class FIXRenderer implements BottomPaneRenderer<String>
 
         public FixStreamConfig addFixFile(final InputStream fixFile)
         {
+            if (fixFile == null)
+            {
+                LOGGER.warn("Tried to add null input stream");
+                return this;
+            }
             fixFiles.add(fixFile);
             return this;
         }
 
         public FixStreamConfig addDefsFixFile(final InputStream defsFixFile)
         {
+            if (defsFixFile == null)
+            {
+                LOGGER.warn("Tried to add null input stream");
+                return this;
+            }
             fixFieldDefsOnly.add(defsFixFile);
             return this;
         }


### PR DESCRIPTION
This is bad input and can cause the parser to blow up further down the
line. Outstanding question about whether the api should really be
taking an InputStream as a parameter